### PR TITLE
feat(openapi-ts-router): add support for Express middlewares

### DIFF
--- a/.changeset/modern-boxes-flash.md
+++ b/.changeset/modern-boxes-flash.md
@@ -1,0 +1,5 @@
+---
+'openapi-ts-router': minor
+---
+
+adds middleware support to Express router

--- a/packages/openapi-ts-router/src/features/with-express/with-express.ts
+++ b/packages/openapi-ts-router/src/features/with-express/with-express.ts
@@ -24,6 +24,7 @@ export function withExpress<GPaths extends object, GFeatures extends TFeatureDef
 				formatPath(path),
 				parseParamsMiddleware(config),
 				validationMiddleware(config),
+				...config.middlewares,
 				requestHandler(config.handler as express.RequestHandler)
 			);
 		},
@@ -32,6 +33,7 @@ export function withExpress<GPaths extends object, GFeatures extends TFeatureDef
 				formatPath(path),
 				parseParamsMiddleware(config),
 				validationMiddleware(config),
+				...config.middlewares,
 				requestHandler(config.handler as express.RequestHandler)
 			);
 		},
@@ -40,6 +42,7 @@ export function withExpress<GPaths extends object, GFeatures extends TFeatureDef
 				formatPath(path),
 				parseParamsMiddleware(config),
 				validationMiddleware(config),
+				...config.middlewares,
 				requestHandler(config.handler as express.RequestHandler)
 			);
 		},
@@ -48,6 +51,7 @@ export function withExpress<GPaths extends object, GFeatures extends TFeatureDef
 				formatPath(path),
 				parseParamsMiddleware(config),
 				validationMiddleware(config),
+				...config.middlewares,
 				requestHandler(config.handler as express.RequestHandler)
 			);
 		},
@@ -56,6 +60,7 @@ export function withExpress<GPaths extends object, GFeatures extends TFeatureDef
 				formatPath(path),
 				parseParamsMiddleware(config),
 				validationMiddleware(config),
+				...config.middlewares,
 				requestHandler(config.handler as express.RequestHandler)
 			);
 		}

--- a/packages/openapi-ts-router/src/features/with-express/with-express.ts
+++ b/packages/openapi-ts-router/src/features/with-express/with-express.ts
@@ -24,7 +24,7 @@ export function withExpress<GPaths extends object, GFeatures extends TFeatureDef
 				formatPath(path),
 				parseParamsMiddleware(config),
 				validationMiddleware(config),
-				...config.middlewares,
+				...(config.middlewares ?? []),
 				requestHandler(config.handler as express.RequestHandler)
 			);
 		},
@@ -33,7 +33,7 @@ export function withExpress<GPaths extends object, GFeatures extends TFeatureDef
 				formatPath(path),
 				parseParamsMiddleware(config),
 				validationMiddleware(config),
-				...config.middlewares,
+				...(config.middlewares ?? []),
 				requestHandler(config.handler as express.RequestHandler)
 			);
 		},
@@ -42,7 +42,7 @@ export function withExpress<GPaths extends object, GFeatures extends TFeatureDef
 				formatPath(path),
 				parseParamsMiddleware(config),
 				validationMiddleware(config),
-				...config.middlewares,
+				...(config.middlewares ?? []),
 				requestHandler(config.handler as express.RequestHandler)
 			);
 		},
@@ -51,7 +51,7 @@ export function withExpress<GPaths extends object, GFeatures extends TFeatureDef
 				formatPath(path),
 				parseParamsMiddleware(config),
 				validationMiddleware(config),
-				...config.middlewares,
+				...(config.middlewares ?? []),
 				requestHandler(config.handler as express.RequestHandler)
 			);
 		},
@@ -60,7 +60,7 @@ export function withExpress<GPaths extends object, GFeatures extends TFeatureDef
 				formatPath(path),
 				parseParamsMiddleware(config),
 				validationMiddleware(config),
-				...config.middlewares,
+				...(config.middlewares ?? []),
 				requestHandler(config.handler as express.RequestHandler)
 			);
 		}

--- a/packages/openapi-ts-router/src/types/features/express.ts
+++ b/packages/openapi-ts-router/src/types/features/express.ts
@@ -101,6 +101,7 @@ export type TOpenApiExpressResponse<GPathOperation> = express.Response<
 // =============================================================================
 
 export type TOpenApiExpressRouteConfig<GPathOperation> = {
+	middlewares?: Array<express.RequestHandler>;
 	handler: TOpenApiExpressRequestHandler<GPathOperation>;
 } & TOpenApiExpressValidators<GPathOperation> &
 	TOpenApiExpressParamsParserOptions;


### PR DESCRIPTION
This PR adds supports for additional middlewares to the Express handlers.