### PR TITLE
feat(openapi-ts-router): add support for express "Local" response types to TOpenApiExpressRequestHandler

### DIFF
--- a/.changeset/cyan-ducks-argue.md
+++ b/.changeset/cyan-ducks-argue.md
@@ -1,0 +1,5 @@
+---
+'openapi-ts-router': minor
+---
+
+adds express Locals type to express request handler

--- a/packages/openapi-ts-router/src/types/features/express.ts
+++ b/packages/openapi-ts-router/src/types/features/express.ts
@@ -67,7 +67,7 @@ export type TOpenApiExpressPatch<GPaths extends object> = <
 // Request Handler
 // =============================================================================
 
-export type TOpenApiExpressRequestHandler<GPathOperation, GResponseLocals = Record<string, any>> = (
+export type TOpenApiExpressRequestHandler<GPathOperation, GResponseLocals extends Record<string, any> = Record<string, any>> = (
 	req: TOpenApiExpressRequest<GPathOperation>,
 	res: TOpenApiExpressResponse<GPathOperation, GResponseLocals>,
 	next: express.NextFunction
@@ -92,7 +92,7 @@ export type TOpenApiExpressPathParams<GPathOperation> =
 
 export type TOpenApiExpressRequestBody<GPathOperation> = TRequestBody<GPathOperation>;
 
-export type TOpenApiExpressResponse<GPathOperation, GResponseLocals = Record<string, any>> = express.Response<
+export type TOpenApiExpressResponse<GPathOperation, GResponseLocals extends Record<string, any> = Record<string, any>> = express.Response<
 	TOperationSuccessResponseContent<GPathOperation>,
 	GResponseLocals
 >;

--- a/packages/openapi-ts-router/src/types/features/express.ts
+++ b/packages/openapi-ts-router/src/types/features/express.ts
@@ -67,9 +67,9 @@ export type TOpenApiExpressPatch<GPaths extends object> = <
 // Request Handler
 // =============================================================================
 
-export type TOpenApiExpressRequestHandler<GPathOperation> = (
+export type TOpenApiExpressRequestHandler<GPathOperation, GResponseLocals = Record<string, any>> = (
 	req: TOpenApiExpressRequest<GPathOperation>,
-	res: TOpenApiExpressResponse<GPathOperation>,
+	res: TOpenApiExpressResponse<GPathOperation, GResponseLocals>,
 	next: express.NextFunction
 ) => Promise<void> | void;
 
@@ -92,8 +92,9 @@ export type TOpenApiExpressPathParams<GPathOperation> =
 
 export type TOpenApiExpressRequestBody<GPathOperation> = TRequestBody<GPathOperation>;
 
-export type TOpenApiExpressResponse<GPathOperation> = express.Response<
-	TOperationSuccessResponseContent<GPathOperation>
+export type TOpenApiExpressResponse<GPathOperation, GResponseLocals = Record<string, any>> = express.Response<
+	TOperationSuccessResponseContent<GPathOperation>,
+	GResponseLocals
 >;
 
 // =============================================================================


### PR DESCRIPTION
When working with the library, I noticed there didn't seem to be a way to define local express context that gets set by middleware (the type param is simply unset).

This change adds support for that optional type declaration for scenarios like defining custom types based on middleware (see example below):
```ts
export type AuthenticatedRequestHandlerById<OperationId extends keyof operations> =
  TOpenApiExpressRequestHandler<
    operations[OperationId],
    { tenant: TenantDocument; user: PopulatedUserDocument }
  >;
```

```ts
export const getDataChecks: AuthenticatedRequestHandlerById<'getDataChecks'> = async (req, res, next) => {
  const { tenant } = res.locals;
```